### PR TITLE
[adsp] Enable AudioDSP add-ons

### DIFF
--- a/adsp.basic/adsp.basic.txt
+++ b/adsp.basic/adsp.basic.txt
@@ -1,1 +1,1 @@
-adsp.basic https://github.com/kodi-adsp/adsp.basic master
+adsp.basic https://github.com/kodi-adsp/adsp.basic v0.2.0

--- a/adsp.basic/platforms.txt
+++ b/adsp.basic/platforms.txt
@@ -1,1 +1,1 @@
-disabled
+!android

--- a/adsp.biquad.filters/adsp.biquad.filters.txt
+++ b/adsp.biquad.filters/adsp.biquad.filters.txt
@@ -1,1 +1,1 @@
-adsp.biquad.filters https://github.com/kodi-adsp/adsp.biquad.filters master
+adsp.biquad.filters https://github.com/kodi-adsp/adsp.biquad.filters v0.0.1

--- a/adsp.biquad.filters/platforms.txt
+++ b/adsp.biquad.filters/platforms.txt
@@ -1,1 +1,1 @@
-disabled
+windows linux

--- a/adsp.freesurround/adsp.freesurround.txt
+++ b/adsp.freesurround/adsp.freesurround.txt
@@ -1,1 +1,1 @@
-adsp.freesurround https://github.com/kodi-adsp/adsp.freesurround master
+adsp.freesurround https://github.com/kodi-adsp/adsp.freesurround v0.2.1

--- a/adsp.freesurround/platforms.txt
+++ b/adsp.freesurround/platforms.txt
@@ -1,1 +1,1 @@
-disabled
+!android


### PR DESCRIPTION
This PR enables all AudioDSP add-ons. 
Currently adsp.biquad.filters is only available for Linux and Windows. Other platforms will follow, when I get a testing device for them.
