### PR TITLE
fix specific version for Jarvis (no p8-platform)

### DIFF
--- a/audiodecoder.ncsf/audiodecoder.ncsf.txt
+++ b/audiodecoder.ncsf/audiodecoder.ncsf.txt
@@ -1,1 +1,1 @@
-audiodecoder.ncsf https://github.com/notspiff/audiodecoder.ncsf db9517fe225f604865a35b17d6a8e2e45cbc22d9
+audiodecoder.ncsf https://github.com/notspiff/audiodecoder.ncsf b452778421e2bb05d6a4e78bc4f4c4bd50c08b01

--- a/audiodecoder.organya/audiodecoder.organya.txt
+++ b/audiodecoder.organya/audiodecoder.organya.txt
@@ -1,1 +1,1 @@
-audiodecoder.organya https://github.com/notspiff/audiodecoder.organya 88d8a0ffa8b53358b28d89d9f29fc13b0f1437aa
+audiodecoder.organya https://github.com/notspiff/audiodecoder.organya ed0d3a51fa58264fd482748581ab2c4cb700eab6

--- a/audiodecoder.qsf/audiodecoder.qsf.txt
+++ b/audiodecoder.qsf/audiodecoder.qsf.txt
@@ -1,1 +1,1 @@
-audiodecoder.qsf https://github.com/notspiff/audiodecoder.qsf 43307294fb162509cf58ba609893d0f3d8ff2d79
+audiodecoder.qsf https://github.com/notspiff/audiodecoder.qsf 83b18d7bcc99e32eee8817e84e4237e8c00398e8


### PR DESCRIPTION
A couple add-ons were pointing to the wrong sha-1 which included the change to p8-platform.
