### PR TITLE
screensaver.rsxs: fix whitespace

### DIFF
--- a/screensavers.rsxs/screensavers.rsxs.txt
+++ b/screensavers.rsxs/screensavers.rsxs.txt
@@ -1,2 +1,1 @@
 screensavers.rsxs https://github.com/notspiff/screensavers.rsxs master
-


### PR DESCRIPTION
This is a reeeeeeeeeeaaally stupid one.
An extra empty line causes this:
> CMake Warning (dev) at /home/hudo/dev/kodiws/kodi/project/cmake/addons/bootstrap/Bootstrap.cmake:28 (list):
  Policy CMP0007 is not set: list command no longer ignores empty elements.
  Run "cmake --help-policy CMP0007" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.  List has value =
  [screensavers.rsxs;https://github.com/notspiff/screensavers.rsxs;master;].
This warning is for project developers.  Use -Wno-dev to suppress it.

Notice the stray "**;**" at the end of the list value...

ping @Montellese, @notspiff, @fetzerch and @wsnipex just so you guys know and can avoid wasting time in the future with such minute crap.