### PR TITLE
pvr.octonet: Update version to 0.3.5

### DIFF
--- a/pvr.octonet/pvr.octonet.txt
+++ b/pvr.octonet/pvr.octonet.txt
@@ -1,1 +1,1 @@
-pvr.octonet https://github.com/DigitalDevices/pvr.octonet 0.3.4
+pvr.octonet https://github.com/DigitalDevices/pvr.octonet 0.3.5


### PR DESCRIPTION
Version 0.3.5 fixes building against the changed plugin api (xbmc/xbmc#10985).