### PR TITLE
pvr.dvbviewer: Bump version to 2.4.6

### DIFF
--- a/pvr.dvbviewer/pvr.dvbviewer.txt
+++ b/pvr.dvbviewer/pvr.dvbviewer.txt
@@ -1,1 +1,1 @@
-pvr.dvbviewer https://github.com/kodi-pvr/pvr.dvbviewer Krypton
+pvr.dvbviewer https://github.com/kodi-pvr/pvr.dvbviewer 2.4.6


### PR DESCRIPTION
v2.4.6 adds support for connection state change callback and removes RTSP, which stopped working in Krypton.