### PR TITLE
pvr.mythtv: move to master branch

### DIFF
--- a/pvr.mythtv/pvr.mythtv.txt
+++ b/pvr.mythtv/pvr.mythtv.txt
@@ -1,1 +1,1 @@
-pvr.mythtv https://github.com/janbar/pvr.mythtv 5.0.8
+pvr.mythtv https://github.com/janbar/pvr.mythtv master


### PR DESCRIPTION
@MartijnKaijser , I have to move the alpha ref to the HEAD of master. Cause I have to remove tags which are not release to avoid confusion with stable and usable tags. Some guys from distributions use release/tag to build there packages for krypton. 