### PR TITLE
Add pvr.rtl.radiofm FM Radio Receiver PVR add-on to binary repo (part 1)

### DIFF
--- a/pvr.rtl.radiofm/pvr.rtl.radiofm.txt
+++ b/pvr.rtl.radiofm/pvr.rtl.radiofm.txt
@@ -1,0 +1,1 @@
+pvr.rtl.radiofm https://github.com/AlwinEsch/pvr.rtl.radiofm master


### PR DESCRIPTION
Add AlwinEsch's pvr.rtl.radiofm FM Radio Receiver PVR add-on to the official repository for Kodi binary add-ons  ( part 1 = pvr.rtl.radiofm.txt )

https://github.com/AlwinEsch/pvr.rtl.radiofm/issues/1
  