### PR TITLE
pvr.vuplus: bump to 2.4.12

### DIFF
--- a/pvr.vuplus/pvr.vuplus.txt
+++ b/pvr.vuplus/pvr.vuplus.txt
@@ -1,1 +1,1 @@
-pvr.vuplus https://github.com/kodi-pvr/pvr.vuplus 2.4.10-Krypton
+pvr.vuplus https://github.com/kodi-pvr/pvr.vuplus 2.4.12-Krypton


### PR DESCRIPTION
After backporting the GAP fixes, version needs to be bumped. (Please wait until a new tag was made)