### PR TITLE
Add 8-player, MIT-licensed, standalone game for multiplayer testing

### DIFF
--- a/game.libretro.mrboom/game.libretro.mrboom.txt
+++ b/game.libretro.mrboom/game.libretro.mrboom.txt
@@ -1,0 +1,1 @@
+game.libretro.mrboom https://github.com/kodi-game/game.libretro.mrboom.git master

--- a/game.libretro.mrboom/platforms.txt
+++ b/game.libretro.mrboom/platforms.txt
@@ -1,0 +1,1 @@
+!windowsstore


### PR DESCRIPTION
This adds Mr.Boom (https://github.com/libretro/mrboom-libretro) for testing the new multiplayer and button-mapping framework added in https://github.com/xbmc/xbmc/pull/13499.

Previously, we just included 2048, which was added so skinners could test support for the In-Game GUI project last summer. The Controller Topology project is the next big addition for RetroPlayer, because for the first time we can model how controllers connect to and map to each other for all of gaming history. Mr.Boom is sufficient for testing because it models both [mapping](https://github.com/kodi-game/game.libretro.mrboom/blob/master/game.libretro.mrboom/resources/buttonmap.xml) and [connecting](https://github.com/kodi-game/game.libretro.mrboom/blob/master/game.libretro.mrboom/resources/topology.xml) multiple controllers and doesn't use ROMs, so it'd be nice to expand testing for this project.