### PR TITLE
[Matrix] change imagedecoder.mpo and imagedecoder.raw to use Matrix branch

### DIFF
--- a/imagedecoder.mpo/imagedecoder.mpo.txt
+++ b/imagedecoder.mpo/imagedecoder.mpo.txt
@@ -1,1 +1,1 @@
-imagedecoder.mpo https://github.com/xbmc/imagedecoder.mpo Leia
+imagedecoder.mpo https://github.com/xbmc/imagedecoder.mpo Matrix

--- a/imagedecoder.raw/imagedecoder.raw.txt
+++ b/imagedecoder.raw/imagedecoder.raw.txt
@@ -1,1 +1,1 @@
-imagedecoder.raw https://github.com/xbmc/imagedecoder.raw Leia
+imagedecoder.raw https://github.com/xbmc/imagedecoder.raw Matrix


### PR DESCRIPTION
The Leia no more work and the addons now available for Matrix.